### PR TITLE
Safer RMI calls in StartServerTsDB

### DIFF
--- a/src/tsdb/remote/DeserializationConfig.java
+++ b/src/tsdb/remote/DeserializationConfig.java
@@ -1,0 +1,49 @@
+package tsdb.remote;
+
+import java.security.Security;
+
+/**
+ * This class helps to configure deserialization.
+ */
+public class DeserializationConfig {
+
+    /**
+     * This filter specifies classes that are allowed for
+     deserialization in RMI communications.
+     *
+     * @see <a href="http://openjdk.java.net/jeps/290">JEP 290: Filter Incoming Serialization Data</a>
+     */
+    private static final String DEFAULT_DESERIALIZATION_FILTER =
+            String.join(";",
+                    "tsdb.**",
+                    "java.lang.Boolean",  "java.lang.Byte",
+                    "java.lang.Character", "java.lang.Double", "java.lang.Enum",
+                    "java.lang.Float", "java.lang.Integer", "java.lang.Long",
+                    "java.lang.Number", "java.lang.Object",
+                    "java.lang.Short",
+                    "java.util.*",
+                    "!*"
+            );
+
+    /**
+     * Returns a process-wide deserialization filter.
+     */
+    private static String getSerialFilter() {
+        String filter = System.getProperty("jdk.serialFilter");
+        if (filter != null) {
+            return filter;
+        }
+        return Security.getProperty("jdk.serialFilter");
+    }
+
+    /**
+     * Sets a process-wide deserialization filter if it is not already set.
+     */
+    public static void setDeserializationFilterIfNecessary() {
+        String filter = getSerialFilter();
+        if (filter == null) {
+            System.out.printf("Use the following filter for deserialization:%n%s%n", DEFAULT_DESERIALIZATION_FILTER);
+            System.setProperty("jdk.serialFilter", DEFAULT_DESERIALIZATION_FILTER);
+        }
+    }
+}

--- a/src/tsdb/remote/StartServerTsDB.java
+++ b/src/tsdb/remote/StartServerTsDB.java
@@ -24,6 +24,7 @@ public class StartServerTsDB {
 	private static final Logger log = LogManager.getLogger();
 
 	public static void main(String[] args) throws RemoteException {
+		DeserializationConfig.setDeserializationFilterIfNecessary();
 
 		log.info("open database...");
 		TsDB tsdb = TsDBFactory.createDefault();


### PR DESCRIPTION
Set a deserialization filter in `StartServerTsDB` for safer RMI communication.

See https://openjdk.java.net/jeps/290

Fixes #10